### PR TITLE
Files to make testing bqt fast and easy

### DIFF
--- a/startup/load_bqt.py
+++ b/startup/load_bqt.py
@@ -1,0 +1,26 @@
+from logging import root
+import sys
+import os
+import inspect
+
+file_name = inspect.getsourcefile(lambda:0)
+root_path = os.path.abspath(os.path.join(os.path.dirname(file_name), os.pardir))
+site_packages = os.path.join(root_path, "env", "Lib", "site-packages")
+
+# if you do not want to install bqt to the site-packages, the root needs to be on sys.path
+# sys.path.append(root_path)
+sys.path.append(site_packages)
+
+import bqt
+
+bqt.register()
+bqt.create_global_app()
+bqt.instantiate_application()
+
+
+def register():
+    pass
+
+
+def unregister():
+    pass

--- a/startup/load_bqt.py
+++ b/startup/load_bqt.py
@@ -1,4 +1,3 @@
-from logging import root
 import sys
 import os
 import inspect

--- a/test_bqt.bat
+++ b/test_bqt.bat
@@ -1,0 +1,15 @@
+echo off
+set "bln_ver=3.2"
+set "bln_dir=C:\Program Files\Blender Foundation\Blender %bln_ver%"
+set "bln_exe=%bln_dir%\blender.exe"
+set "bln_py=%bln_dir%\%bln_ver%\python\bin\python.exe"
+
+call "%bln_py%" -m venv env
+call "%~dp0env\Scripts\activate"
+
+SET PIP_DISABLE_PIP_VERSION_CHECK=1
+call python -m pip install -r requirements.txt
+call python -m pip install %~dp0 --use-feature=in-tree-build
+
+set "BLENDER_USER_SCRIPTS=%~dp0"
+call "%bln_exe%"


### PR DESCRIPTION
An easy to use (and modify) bat file for Windows based users to quickly test bqt in a running Blender version and emulate a real studio setup.